### PR TITLE
Port missing Huabao/JT808 power decoding branches from upstream

### DIFF
--- a/src/main/java/org/traccar/helper/BufferUtil.java
+++ b/src/main/java/org/traccar/helper/BufferUtil.java
@@ -44,4 +44,16 @@ public final class BufferUtil {
         return result < 0 ? result : haystack.readerIndex() + result;
     }
 
+    public static boolean isPrintable(ByteBuf buf, int length) {
+        boolean printable = true;
+        for (int i = 0; i < length; i++) {
+            byte b = buf.getByte(buf.readerIndex() + i);
+            if (b < 32 && b != '\r' && b != '\n') {
+                printable = false;
+                break;
+            }
+        }
+        return printable;
+    }
+
 }

--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -25,6 +25,7 @@ import org.traccar.NetworkMessage;
 import org.traccar.Protocol;
 import org.traccar.helper.BcdUtil;
 import org.traccar.helper.BitUtil;
+import org.traccar.helper.BufferUtil;
 import org.traccar.helper.Checksum;
 import org.traccar.helper.DateBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -719,6 +720,9 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
                     endIndex = buf.writerIndex() - 2;
                     decodeExtension(position, buf, endIndex);
                     break;
+                case 0x82:
+                    position.set(Position.KEY_POWER, buf.readUnsignedShort() * 0.1);
+                    break;
                 case 0x91:
                     position.set(Position.KEY_BATTERY, buf.readUnsignedShort() * 0.1);
                     position.set(Position.KEY_RPM, buf.readUnsignedShort());
@@ -767,6 +771,8 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
                 case 0xE1:
                     if (length == 1) {
                         position.set(Position.KEY_BATTERY_LEVEL, buf.readUnsignedByte());
+                    } else if (subtype == 0xE1 && length == 2) {
+                        position.set(Position.KEY_POWER, buf.readUnsignedShort() * 0.1);
                     } else {
                         position.set(Position.KEY_DRIVER_UNIQUE_ID, String.valueOf(buf.readUnsignedInt()));
                     }
@@ -804,7 +810,7 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
                     }
                     break;
                 case 0xEB:
-                    if (buf.getUnsignedShort(buf.readerIndex()) > 200) {
+                    if (buf.getUnsignedShort(buf.readerIndex()) > 200 && (length - 3) % 5 == 0) {
                         Network network = new Network();
                         int mcc = buf.readUnsignedShort();
                         int mnc = buf.readUnsignedByte();
@@ -814,6 +820,8 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
                                     buf.readUnsignedByte()));
                         }
                         position.setNetwork(network);
+                    } else if (BufferUtil.isPrintable(buf, length)) {
+                        position.set("timezone", buf.readCharSequence(length, StandardCharsets.US_ASCII).toString());
                     } else {
                         while (buf.readerIndex() < endIndex) {
                             int extendedLength = buf.readUnsignedShort();
@@ -826,6 +834,13 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
                                 case 0x0023:
                                     position.set("fuel2", Double.parseDouble(
                                             buf.readCharSequence(6, StandardCharsets.US_ASCII).toString()));
+                                    break;
+                                case 0x002D:
+                                    if (extendedLength == 6) {
+                                        position.set(Position.KEY_POWER, buf.readUnsignedInt() * 0.001);
+                                    } else {
+                                        position.set(Position.KEY_BATTERY, buf.readUnsignedShort() * 0.001);
+                                    }
                                     break;
                                 case 0x00B2:
                                     position.set(Position.KEY_ICCID, ByteBufUtil.hexDump(

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
@@ -129,6 +129,25 @@ public class HuabaoProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, binary(
                 "7e020000220014012499170007000000000000400e012af16f02cbd2ba000000000000150101194257010400000077a97e"));
 
+        verifyAttribute(decoder, binary(
+                "7e020000200135112211220007000000000000000002625a00007a1200000000000000250902120000820200dc237e"),
+                Position.KEY_POWER, 22.0);
+
+        verifyAttribute(decoder, binary(
+                "7e020000200135112211220008000000000000000002625a00007a1200000000000000250902120000e10200891a7e"),
+                Position.KEY_POWER, 13.7);
+
+        verifyAttribute(decoder, binary(
+                "7e020000260135112211220009000000000000000002625a00007a1200000000000000250902120000"
+                        + "eb080006002d000035e8627e"),
+                Position.KEY_POWER, 13.8);
+
+        verifyAttribute(decoder, binary(
+                "7e0200006a4eb6fb4ad8e2002e00000000004c000f015da88d02b57bb6021e007d00b426090217080201"
+                        + "040000000025040000000030011f310112eb095554432d30333a3030642f00000000000401000000"
+                        + "000007021e015da8a802b57bb62609021708020400000000000000002609021708020007007c7e"),
+                "timezone", "UTC-03:00");
+
     }
 
 }


### PR DESCRIPTION
Compared against upstream traccar/traccar's Jt808ProtocolDecoder and ported three power-related gaps found in this fork's Huabao decoder:

- top-level subtype 0x82 -> KEY_POWER, previously dropped entirely
- subtype 0xE1 with a 2-byte payload -> KEY_POWER, previously misread as a driverUniqueId
- subtype 0xEB extended type 0x002D -> KEY_POWER/KEY_BATTERY, plus the printable-string guard (upstream's BufferUtil.isPrintable) so a printable payload like a "UTC-03:00" timezone string is read as such instead of being misparsed as a bogus cell tower


Claude-Session: https://claude.ai/code/session_01YQ11SGejyCmixnuWf7Y6RT