### PR TITLE
Decode Huabao 0x0800 multimedia event upload

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -70,6 +70,7 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_LOCATION_BATCH = 0x0704;
     public static final int MSG_TIME_SYNC_REQUEST = 0x0109;
     public static final int MSG_PHOTO = 0x8888;
+    public static final int MSG_MULTIMEDIA_EVENT = 0x0800;
     public static final int MSG_TRANSPARENT = 0x0900;
     public static final int MSG_TRANSPARENT_DOWNLINK = 0x8900;
     public static final int MSG_REPORT_TEXT_MESSAGE = 0x6006;
@@ -337,6 +338,12 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
             sendGeneralResponse(channel, remoteAddress, id, type, index);
 
             return decodeLocation(deviceSession, buf, type);
+
+        } else if (type == MSG_MULTIMEDIA_EVENT) {
+
+            sendGeneralResponse(channel, remoteAddress, id, type, index);
+
+            return decodeMultimediaEvent(deviceSession, buf);
 
         } else if (type == MSG_LOCATION_REPORT_2 || type == MSG_LOCATION_REPORT_BLIND) {
 
@@ -988,6 +995,29 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
             }
             buf.readerIndex(endIndex);
         }
+
+        return position;
+    }
+
+    private Position decodeMultimediaEvent(DeviceSession deviceSession, ByteBuf buf) {
+
+        Position position = new Position(getProtocolName());
+        position.setDeviceId(deviceSession.getDeviceId());
+
+        position.set("mediaId", buf.readUnsignedInt());
+        position.set("mediaType", buf.readUnsignedByte());
+        position.set("mediaFormat", buf.readUnsignedByte());
+        position.set("mediaEvent", buf.readUnsignedByte());
+        position.set("mediaChannel", buf.readUnsignedByte());
+
+        position.set(Position.KEY_ALARM, decodeAlarm(buf.readUnsignedInt()));
+
+        decodeCoordinates(position, buf);
+
+        position.setAltitude(buf.readShort());
+        position.setSpeed(UnitsConverter.knotsFromKph(buf.readUnsignedShort() * 0.1));
+        position.setCourse(buf.readUnsignedShort());
+        position.setTime(readDate(buf, deviceSession.get(DeviceSession.KEY_TIMEZONE)));
 
         return position;
     }

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
@@ -42,6 +42,10 @@ public class HuabaoProtocolDecoderTest extends ProtocolTest {
                         + "\"fileSize\":1000000}]");
 
         verifyAttribute(decoder, binary(
+                "7e080000240133456789060002000000010200030100000000000000020098968001312d000005000000002609041200001d7e"),
+                "mediaEvent", 3);
+
+        verifyAttribute(decoder, binary(
                 "7e550104337401903111850622072002454206133574075359513a0000080100000001aa00005ded05e203000000000c06005affb5ffb40a0302dc65100100137e"),
                 Position.KEY_CHARGE, true);
 


### PR DESCRIPTION
## Summary
- Adds decoding for JT/T 808 message `0x0800` (Multimedia Event Information Upload) in `HuabaoProtocolDecoder`, which was previously falling through to the decoder's final `return null` and being silently discarded — same gap that exists in upstream `traccar/traccar`'s `Jt808ProtocolDecoder`.
- Devices (e.g. the Jimi JC450 camera fleet) use this message to report alarm-triggered media (photo/video) tagged with an event code (0=platform command, 1=timed, 2=robbery alarm, 3=collision/rollover, vendor-extensible beyond that) — this is a separate mechanism from the `0x1205` resource-list query, whose generic alarm bitmask has been observed as `0` across every sampled recording.
- New `decodeMultimediaEvent()` parses the message's 36-byte body per the public JT/T 808 spec, reusing the existing `decodeAlarm`/`decodeCoordinates` helpers already used for `0x0200` location reports, and exposes `mediaId`, `mediaType`, `mediaFormat`, `mediaEvent`, `mediaChannel` as position attributes.

## Test plan
- [x] `HuabaoProtocolDecoderTest` updated with a hand-built, checksum-correct synthetic `0x0800` frame asserting `mediaEvent` decodes to `3`.
- [x] Compiled and ran the suite with JDK 11 (required for this repo's Gradle 6.7); only pre-existing, unrelated failure is a floating-point precision flake in a `KEY_POWER` assertion from a prior commit (`c8bd935e5`), not touched by this change.
- [ ] Not yet verified against a real device frame — built from the public JT/T 808 spec only. Next real alarm from this device fleet should be captured and cross-checked before fully trusting the field layout in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)