### PR TITLE
Promote to hetzner: Huabao 0x8103 set-parameter command

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocol.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocol.java
@@ -31,7 +31,8 @@ public class HuabaoProtocol extends BaseProtocol {
                 Command.TYPE_VIDEO_STOP,
                 Command.TYPE_VIDEO_LIST,
                 Command.TYPE_VIDEO_PLAYBACK,
-                Command.TYPE_GET_DEVICE_STATUS);
+                Command.TYPE_GET_DEVICE_STATUS,
+                Command.TYPE_CONFIGURATION);
         addServer(new TrackerServer(false, getName()) {
             @Override
             protected void addProtocolHandlers(PipelineBuilder pipeline) {

--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -82,6 +82,7 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_VIDEO_PLAYBACK = 0x9201;
     public static final int MSG_VIDEO_LIST = 0x9205;
     public static final int MSG_VIDEO_LIST_RESPONSE = 0x1205;
+    public static final int MSG_SET_PARAMETERS = 0x8103;
     public static final int MSG_QUERY_PARAMETERS = 0x8104;
     public static final int MSG_PARAMETERS_RESPONSE = 0x0104;
 
@@ -274,7 +275,8 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
                     || responseType == MSG_VIDEO_REQUEST
                     || responseType == MSG_VIDEO_CONTROL
                     || responseType == MSG_VIDEO_PLAYBACK
-                    || responseType == MSG_VIDEO_LIST) {
+                    || responseType == MSG_VIDEO_LIST
+                    || responseType == MSG_SET_PARAMETERS) {
                 Position position = new Position(getProtocolName());
                 position.setDeviceId(deviceSession.getDeviceId());
                 getLastLocation(position, null);

--- a/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
@@ -78,6 +78,13 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
         data.writeByte(0); // all storage types
     }
 
+    static void encodeSetParameterData(ByteBuf data, int parameterId, byte[] value) {
+        data.writeByte(1); // one parameter
+        data.writeInt(parameterId);
+        data.writeByte(value.length);
+        data.writeBytes(value);
+    }
+
     static void encodeVideoRequestData(ByteBuf data, String server, int port, int channel) {
         data.writeByte(server.length());
         data.writeCharSequence(server, StandardCharsets.US_ASCII);
@@ -173,6 +180,18 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
                     // 0x8104 query all terminal parameters, empty body; device replies with 0x0104
                     return HuabaoProtocolDecoder.formatMessage(
                             HuabaoProtocolDecoder.MSG_QUERY_PARAMETERS, id, false, data);
+                case Command.TYPE_CONFIGURATION: {
+                    // 0x8103 set terminal parameters, single entry:
+                    // count(1) + parameter id(4) + parameter length(1) + value(length)
+                    int parameterId = command.getInteger(Command.KEY_INDEX);
+                    byte[] value = DataConverter.parseHex(command.getString(Command.KEY_DATA));
+                    encodeSetParameterData(data, parameterId, value);
+                    LOGGER.error(
+                            "Huabao set parameter encoded deviceId={} id=0x{} length={}",
+                            command.getDeviceId(), Integer.toHexString(parameterId).toUpperCase(), value.length);
+                    return HuabaoProtocolDecoder.formatMessage(
+                            HuabaoProtocolDecoder.MSG_SET_PARAMETERS, id, false, data);
+                }
                 default:
                     return null;
             }

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolEncoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolEncoderTest.java
@@ -57,6 +57,18 @@ public class HuabaoProtocolEncoderTest extends ProtocolTest {
         }
     }
 
+    @Test
+    public void testEncodeSetParameter() {
+        ByteBuf data = Unpooled.buffer();
+        try {
+            HuabaoProtocolEncoder.encodeSetParameterData(
+                    data, 0x0079, ByteBufUtil.decodeHexDump("ffffff"));
+            assertEquals("010000007903ffffff", ByteBufUtil.hexDump(data));
+        } finally {
+            data.release();
+        }
+    }
+
     @Ignore
     @Test
     public void testEncode() throws Exception {


### PR DESCRIPTION
Promotes `fleetmap` → `hetzner` (production). One commit:

**`b220df968` — Add Huabao 0x8103 set-parameter command**

- `TYPE_CONFIGURATION` now encodes a single-parameter JT/T 808 `0x8103`: `count(1) + parameter id(4) + length(1) + value(bytes)`. Parameter id comes from `KEY_INDEX`, raw hex value from `KEY_DATA`.
- The `0x0001` ack for `0x8103` is surfaced as `KEY_RESULT` (`"0x8103 accepted"` / `"rejected: <n>"`).
- Body building is in the static `encodeSetParameterData()` helper, covered by a unit test (`010000007903ffffff`).
- Pairs with the already-deployed `getDeviceStatus` (`0x8104`) query so a caller can read a parameter block, modify one field, and write it back.

## Why

The camera fleet has no ADAS/DSM active-safety detection provisioned (confirmed via `0x8104` dumps — `0xF364`/`0xF365` blocks are all-zero or absent). This command is what lets the platform write those parameters. The frontend counterpart (per-parameter "Ativar" buttons) is [traccar-vue-element#1947](https://github.com/fleetmap-io/traccar-vue-element/pull/1947).

## Risk

- Encoder only sends what it is told; no behaviour change for existing commands.
- The actual risk lives in *what values* get sent — the frontend restricts this to single well-defined fields (alarm mask, `AlarmEnable` bits), one camera at a time, behind a confirm. Nothing auto-applies.
- Compiles on JDK 11 / Gradle 6.7; `HuabaoProtocolEncoderTest` + `HuabaoProtocolDecoderTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)