### PR TITLE
Promote to hetzner: Huabao 0x8107 query-terminal-attributes

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocol.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocol.java
@@ -32,6 +32,7 @@ public class HuabaoProtocol extends BaseProtocol {
                 Command.TYPE_VIDEO_LIST,
                 Command.TYPE_VIDEO_PLAYBACK,
                 Command.TYPE_GET_DEVICE_STATUS,
+                Command.TYPE_GET_VERSION,
                 Command.TYPE_CONFIGURATION);
         addServer(new TrackerServer(false, getName()) {
             @Override

--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -85,6 +85,8 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_SET_PARAMETERS = 0x8103;
     public static final int MSG_QUERY_PARAMETERS = 0x8104;
     public static final int MSG_PARAMETERS_RESPONSE = 0x0104;
+    public static final int MSG_QUERY_ATTRIBUTES = 0x8107;
+    public static final int MSG_ATTRIBUTES_RESPONSE = 0x0107;
 
     public static final int RESULT_SUCCESS = 0;
 
@@ -351,6 +353,47 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
             parameters.append('}');
 
             position.set("parameters", parameters.toString());
+            sendGeneralResponse(channel, remoteAddress, id, type, index);
+            return position;
+
+        } else if (type == MSG_ATTRIBUTES_RESPONSE) {
+
+            Position position = new Position(getProtocolName());
+            position.setDeviceId(deviceSession.getDeviceId());
+            getLastLocation(position, null);
+
+            byte[] raw = ByteBufUtil.getBytes(buf, buf.readerIndex(), Math.min(bodyLength, buf.readableBytes()));
+
+            int terminalType = buf.readUnsignedShort();
+            String manufacturer = buf.readCharSequence(5, StandardCharsets.US_ASCII).toString().trim();
+            String model = buf.readCharSequence(20, StandardCharsets.US_ASCII).toString().trim();
+            buf.skipBytes(7); // terminal id
+            buf.skipBytes(10); // sim iccid
+            String hardware = "";
+            String firmware = "";
+            if (buf.readableBytes() >= 1) {
+                int length = buf.readUnsignedByte();
+                if (length > 0 && length <= buf.readableBytes()) {
+                    hardware = buf.readCharSequence(length, StandardCharsets.US_ASCII).toString().trim();
+                }
+            }
+            if (buf.readableBytes() >= 1) {
+                int length = buf.readUnsignedByte();
+                if (length > 0 && length <= buf.readableBytes()) {
+                    firmware = buf.readCharSequence(length, StandardCharsets.US_ASCII).toString().trim();
+                }
+            }
+
+            LOGGER.error(
+                    "Huabao terminal attributes deviceId={} type=0x{} manufacturer={} model={} hardware={} firmware={} "
+                            + "raw={}",
+                    deviceSession.getDeviceId(), Integer.toHexString(terminalType).toUpperCase(),
+                    manufacturer, model, hardware, firmware, ByteBufUtil.hexDump(raw));
+
+            position.set("terminalModel", model.replaceAll("\\p{C}", ""));
+            position.set(Position.KEY_VERSION_HW, hardware.replaceAll("\\p{C}", ""));
+            position.set(Position.KEY_VERSION_FW, firmware.replaceAll("\\p{C}", ""));
+
             sendGeneralResponse(channel, remoteAddress, id, type, index);
             return position;
 

--- a/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
@@ -180,18 +180,22 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
                     // 0x8104 query all terminal parameters, empty body; device replies with 0x0104
                     return HuabaoProtocolDecoder.formatMessage(
                             HuabaoProtocolDecoder.MSG_QUERY_PARAMETERS, id, false, data);
-                case Command.TYPE_CONFIGURATION: {
+                case Command.TYPE_GET_VERSION:
+                    // 0x8107 query terminal attributes, empty body; device replies with 0x0107
+                    return HuabaoProtocolDecoder.formatMessage(
+                            HuabaoProtocolDecoder.MSG_QUERY_ATTRIBUTES, id, false, data);
+                case Command.TYPE_CONFIGURATION:
                     // 0x8103 set terminal parameters, single entry:
                     // count(1) + parameter id(4) + parameter length(1) + value(length)
                     int parameterId = command.getInteger(Command.KEY_INDEX);
-                    byte[] value = DataConverter.parseHex(command.getString(Command.KEY_DATA));
-                    encodeSetParameterData(data, parameterId, value);
+                    byte[] parameterValue = DataConverter.parseHex(command.getString(Command.KEY_DATA));
+                    encodeSetParameterData(data, parameterId, parameterValue);
                     LOGGER.error(
                             "Huabao set parameter encoded deviceId={} id=0x{} length={}",
-                            command.getDeviceId(), Integer.toHexString(parameterId).toUpperCase(), value.length);
+                            command.getDeviceId(), Integer.toHexString(parameterId).toUpperCase(),
+                            parameterValue.length);
                     return HuabaoProtocolDecoder.formatMessage(
                             HuabaoProtocolDecoder.MSG_SET_PARAMETERS, id, false, data);
-                }
                 default:
                     return null;
             }

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
@@ -50,6 +50,11 @@ public class HuabaoProtocolDecoderTest extends ProtocolTest {
                 "parameters", "{\"0x1\":\"0000003c\",\"0x18\":\"00002710\"}");
 
         verifyAttribute(decoder, binary(
+                "7e01070038013345678906000100404a494d49004a433435300000000000000000000000000000003030303030303189"
+                        + "86000000000000000103312e3005322e332e310000f97e"),
+                Position.KEY_VERSION_FW, "2.3.1");
+
+        verifyAttribute(decoder, binary(
                 "7e550104337401903111850622072002454206133574075359513a0000080100000001aa00005ded05e203000000000c06005affb5ffb40a0302dc65100100137e"),
                 Position.KEY_CHARGE, true);
 


### PR DESCRIPTION
Promotes `fleetmap` → `hetzner` (production). One commit:

**`db007f6bd` — Add Huabao 0x8107 query-terminal-attributes command**

- `TYPE_GET_VERSION` (`"getVersion"`) sends JT/T 808 `0x8107` (empty body).
- The `0x0107` reply is decoded into `terminalModel` / `versionHw` / `versionFw` position attributes and logged at ERROR level — including the **full raw body hex**, so the model/hw/fw strings are visible in CloudWatch even if the fixed-field offsets vary by protocol version.
- Parses the JT/T 808-2013 body layout (manufacturer[5], model[20], terminalId[7], iccid[10], then length-prefixed hw/fw version strings) — matches this decoder's existing 6-byte-phone framing. All length reads are bounds-checked, so a 2019-format or vendor-variant body degrades to empty strings + raw hex rather than throwing.
- Also removes a nested `{}` block in the `0x8103` case to satisfy checkstyle.

## Why

Diagnostic: 400111 (JC371) is the only camera in the fleet that ever exposed ADAS/DSM parameters, and it lost them after a reboot. This lets us compare **firmware/model** across cameras to confirm whether 400111 runs different firmware — informs whether the fix is provisioning or a Jimi firmware request. `VERSION#` doesn't work here because JC181/JC371 text replies come back as `0x0900` subtype `0xF0`, which the decoder parses as binary telemetry.

## Risk

- Additive: new command type + new decode branch. No change to existing commands or decoders.
- Compiles on JDK 11 / Gradle 6.7; `HuabaoProtocolEncoderTest` + `HuabaoProtocolDecoderTest` pass; no new checkstyle violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)