### PR TITLE
Promote to hetzner: log manufacturer/model from Huabao registration

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -399,6 +399,20 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
 
         } else if (type == MSG_TERMINAL_REGISTER) {
 
+            if (bodyLength >= 29) {
+                int available = Math.min(bodyLength, buf.readableBytes());
+                byte[] registration = ByteBufUtil.getBytes(buf, buf.readerIndex(), available);
+                buf.skipBytes(4); // province and city id
+                String manufacturer = buf.readCharSequence(5, StandardCharsets.US_ASCII).toString();
+                String model = buf.readCharSequence(20, StandardCharsets.US_ASCII).toString();
+                LOGGER.error(
+                        "Huabao terminal register deviceId={} manufacturer={} model={} raw={}",
+                        deviceSession.getDeviceId(),
+                        manufacturer.replaceAll("\\p{C}", ""),
+                        model.replaceAll("\\p{C}", ""),
+                        ByteBufUtil.hexDump(registration));
+            }
+
             if (channel != null) {
                 ByteBuf response = Unpooled.buffer();
                 response.writeShort(index);


### PR DESCRIPTION
Promotes `fleetmap` → `hetzner` (production). One commit:

**`2be4c36f6` — Log manufacturer and model from Huabao 0x0100 registration**

- The JT/T 808 terminal-register message body carries manufacturer id + terminal model; Traccar was reading nothing from it.
- Now logs `Huabao terminal register deviceId=… manufacturer=… model=… raw=<hex>` at ERROR level whenever a device registers.
- Parsed as JT/T 808-2013 layout (province+city 4 bytes, manufacturer[5], model[20]), guarded on body length, read-only — cannot affect the register response that's sent back.

## Why

400111 (JC371) is faulted — it returns `result=1` (failure) to `0x8107`, an empty list to `0x8104`, and is silent on `VERSION#`. Since every device sends its model in the registration on (re)connect, this surfaces 400111's model the moment it power-cycles, with no query needed — and confirms whether it's a genuinely different model/firmware or just a broken unit.

## Risk

Additive logging only, inside the existing `MSG_TERMINAL_REGISTER` branch. Tests pass (`HuabaoProtocolDecoderTest` includes register frames), no new checkstyle violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)