### PR TITLE
Promote to hetzner: Huabao 0x8106 query-specific-parameters

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -84,6 +84,7 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
     public static final int MSG_VIDEO_LIST_RESPONSE = 0x1205;
     public static final int MSG_SET_PARAMETERS = 0x8103;
     public static final int MSG_QUERY_PARAMETERS = 0x8104;
+    public static final int MSG_QUERY_SPECIFIC_PARAMETERS = 0x8106;
     public static final int MSG_PARAMETERS_RESPONSE = 0x0104;
     public static final int MSG_QUERY_ATTRIBUTES = 0x8107;
     public static final int MSG_ATTRIBUTES_RESPONSE = 0x0107;

--- a/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
@@ -85,6 +85,26 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
         data.writeBytes(value);
     }
 
+    static int[] parseParameterIds(String value) {
+        String[] parts = value.split("[ ,]+");
+        int[] ids = new int[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            String part = parts[i].trim();
+            if (part.startsWith("0x") || part.startsWith("0X")) {
+                part = part.substring(2);
+            }
+            ids[i] = (int) Long.parseLong(part, 16);
+        }
+        return ids;
+    }
+
+    static void encodeQuerySpecificParameterData(ByteBuf data, int[] parameterIds) {
+        data.writeByte(parameterIds.length);
+        for (int parameterId : parameterIds) {
+            data.writeInt(parameterId);
+        }
+    }
+
     static void encodeVideoRequestData(ByteBuf data, String server, int port, int channel) {
         data.writeByte(server.length());
         data.writeCharSequence(server, StandardCharsets.US_ASCII);
@@ -177,7 +197,15 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
                     return HuabaoProtocolDecoder.formatMessage(
                             HuabaoProtocolDecoder.MSG_VIDEO_PLAYBACK, id, false, data);
                 case Command.TYPE_GET_DEVICE_STATUS:
-                    // 0x8104 query all terminal parameters, empty body; device replies with 0x0104
+                    // No data: 0x8104 query all terminal parameters (empty body).
+                    // Data present: comma-separated parameter ids -> 0x8106 query specific.
+                    // Either way the device replies with 0x0104.
+                    String parameterIds = command.getString(Command.KEY_DATA);
+                    if (parameterIds != null && !parameterIds.isEmpty()) {
+                        encodeQuerySpecificParameterData(data, parseParameterIds(parameterIds));
+                        return HuabaoProtocolDecoder.formatMessage(
+                                HuabaoProtocolDecoder.MSG_QUERY_SPECIFIC_PARAMETERS, id, false, data);
+                    }
                     return HuabaoProtocolDecoder.formatMessage(
                             HuabaoProtocolDecoder.MSG_QUERY_PARAMETERS, id, false, data);
                 case Command.TYPE_GET_VERSION:

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolEncoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolEncoderTest.java
@@ -69,6 +69,18 @@ public class HuabaoProtocolEncoderTest extends ProtocolTest {
         }
     }
 
+    @Test
+    public void testEncodeQuerySpecificParameter() {
+        ByteBuf data = Unpooled.buffer();
+        try {
+            HuabaoProtocolEncoder.encodeQuerySpecificParameterData(
+                    data, HuabaoProtocolEncoder.parseParameterIds("64, 65, 0xf364, F365"));
+            assertEquals("0400000064000000650000f3640000f365", ByteBufUtil.hexDump(data));
+        } finally {
+            data.release();
+        }
+    }
+
     @Ignore
     @Test
     public void testEncode() throws Exception {


### PR DESCRIPTION
Promotes `fleetmap` → `hetzner` (production).

**Add Huabao 0x8106 query-specific-parameters**

- `getDeviceStatus` now branches on `KEY_DATA`:
  - **absent** → `0x8104` (query all terminal parameters) — unchanged behaviour
  - **comma-separated parameter ids** (e.g. `"64,65,f364,f365,f367"`) → `0x8106` (query specific), body `count(1) + id(4)×count`
- Reply is `0x0104` in both cases, already decoded into the `parameters` attribute — no decoder change.
- Static helpers `parseParameterIds()` (accepts `0x`-prefixed or bare hex) + `encodeQuerySpecificParameterData()`, with a unit test (`0400000064000000650000f3640000f365`).

## Why

The JC450 fleet returns no ADAS/DSM blocks in a `0x8104` "query all" dump. Many JT808 devices only return standard params for "query all" and require `0x8106` to return extended/vendor blocks by id. This is the probe: ask a JC450 point-blank for `0x64`/`0x65`/`0xF364`/`0xF365` — if they come back, active safety is there but unadvertised; if not, the firmware confirms it.

Frontend counterpart is on `dev` (traccar-vue-element): "Verificar configuração" now also fires the `0x8106` probe and merges both replies.

## Risk

Additive. Existing `getDeviceStatus` calls (no data) are byte-for-byte unchanged. Compiles on JDK 11 / Gradle 6.7; encoder + decoder tests pass; no new checkstyle violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)