### PR TITLE
Promote to hetzner: decode text replies on Huabao 0x0900/0xF0

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -1292,6 +1292,21 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
 
         } else if (type == 0xF0) {
 
+            if (buf.readableBytes() > 2 && BufferUtil.isPrintable(buf, buf.readableBytes() - 2)) {
+                Position position = new Position(getProtocolName());
+                position.setDeviceId(deviceSession.getDeviceId());
+                getLastLocation(position, null);
+                String result = buf.readCharSequence(
+                        buf.readableBytes() - 2, StandardCharsets.US_ASCII).toString().trim();
+                LOGGER.error(
+                        "Huabao transparent text deviceId={} result={}",
+                        deviceSession.getDeviceId(), result.replace("\r", "\\r").replace("\n", "\\n"));
+                if (!result.isEmpty()) {
+                    position.set(Position.KEY_RESULT, result);
+                }
+                return position.getAttributes().isEmpty() ? null : position;
+            }
+
             Position position = new Position(getProtocolName());
             position.setDeviceId(deviceSession.getDeviceId());
 

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
@@ -19,6 +19,10 @@ public class HuabaoProtocolDecoderTest extends ProtocolTest {
                 Position.KEY_RESULT, "RTMP,OK");
 
         verifyAttribute(decoder, binary(
+                "7e0900000c0133456789060001f056455253494f4e2e312e30307e"),
+                Position.KEY_RESULT, "VERSION.1.0");
+
+        verifyAttribute(decoder, binary(
                 "7e0701000b01334567890600010000000752544d502c4f4ba77e"),
                 Position.KEY_RESULT, "RTMP,OK");
 


### PR DESCRIPTION
Promotes `fleetmap` → `hetzner` (production).

**Decode text replies on the Huabao 0x0900 0xF0 subtype**

- JC181 / JC371 answer text commands (`VERSION#`, etc.) with a transparent `0x0900` subtype `0xF0` message. `decodeTransparent()` always parsed the `0xF0` subtype as binary E8/OBD telemetry, so the text was discarded.
- Now: if the `0xF0` payload is printable ASCII (`BufferUtil.isPrintable`), it's surfaced as `KEY_RESULT` and logged (`Huabao transparent text deviceId=… result=…`), same as the existing `0x40` branch. Otherwise it falls through to the binary parser unchanged — binary telemetry fails the printable check (BCD date bytes are `< 0x20`).

## Why

We can send text commands to all camera models via `type: custom`, but only JC450 replies (subtype `0x40`) were readable. This makes JC181/JC371 text replies readable too — useful for `VERSION#` and any Jimi text command on those models.

## Risk

Additive guard at the top of the `0xF0` branch; existing binary path untouched. Compiles JDK 11 / Gradle 6.7; decoder + encoder tests pass (new test: `0x0900/0xF0` `"VERSION.1.0"` → `KEY_RESULT`); no new checkstyle violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)