### PR TITLE
Send JC450 text commands as 0xF0 transparent

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
@@ -37,12 +37,13 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
 
     private static final int DEVICE_TYPE_JC181 = 55;
     private static final int DEVICE_TYPE_JC371 = 56;
+    private static final int DEVICE_TYPE_JC450 = 57;
 
     public HuabaoProtocolEncoder(Protocol protocol) {
         super(protocol);
     }
 
-    private ByteBuf encodeTransparent(ByteBuf id, String payload, int subtype) {
+    static ByteBuf encodeTransparent(ByteBuf id, String payload, int subtype) {
         ByteBuf data = Unpooled.buffer();
         data.writeByte(subtype);
         data.writeBytes(payload.getBytes(StandardCharsets.US_ASCII));
@@ -137,8 +138,9 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
                     String payload = command.getString(Command.KEY_DATA);
                     int deviceType = Context.getIdentityManager().lookupAttributeInteger(
                             command.getDeviceId(), "deviceType", 0, false, false);
-                    boolean jimiOnlineCommand =
-                            deviceType == DEVICE_TYPE_JC181 || deviceType == DEVICE_TYPE_JC371;
+                    boolean jimiOnlineCommand = deviceType == DEVICE_TYPE_JC181
+                            || deviceType == DEVICE_TYPE_JC371
+                            || deviceType == DEVICE_TYPE_JC450;
                     int subtype = jimiOnlineCommand ? 0xF0 : 0x40;
                     LOGGER.error(
                             "Huabao command encoded deviceId={} deviceType={} subtype=0x{} payload={}",

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolEncoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolEncoderTest.java
@@ -70,6 +70,23 @@ public class HuabaoProtocolEncoderTest extends ProtocolTest {
     }
 
     @Test
+    public void testEncodeTransparentJimiText() {
+        ByteBuf id = HuabaoProtocolEncoder.encodeTerminalId("869247060610265");
+        try {
+            ByteBuf frame = HuabaoProtocolEncoder.encodeTransparent(id, "DMSSEP,1,1#", 0xF0);
+            try {
+                assertEquals(
+                        "7e8900000c4f0ebc3a1ae20001f0444d535345502c312c3123747e",
+                        ByteBufUtil.hexDump(frame));
+            } finally {
+                frame.release();
+            }
+        } finally {
+            id.release();
+        }
+    }
+
+    @Test
     public void testEncodeQuerySpecificParameter() {
         ByteBuf data = Unpooled.buffer();
         try {


### PR DESCRIPTION
## What

JC450 (`deviceType` 57) text config commands (`DMSSEP,1,1#`, `ADASSEN,...#`, etc.) sent via Traccar `type:custom` were encoded with transparent subtype `0x40`. They need `0xF0`, the same as JC181/JC371.

## Evidence

Stood up the Jimi IoTHub stack and registered a stub JT/T 808 terminal against `jimi-gateway-450` on `:21122`, then fired `sendInstruct` with `proNo=128` / `cmdContent=DMSSEP,1,1#` and captured the downlink:

```
7e 8900 000c 4f0ebc3a1ae2 0001  f0 444d535345502c312c3123  74 7e
                                 ^^ subtype              "DMSSEP,1,1#"
```

Body = `0xF0` + raw ASCII. No base64, no query/set flag, no newline — identical to the JC181/JC371 form.

## Change

- Include `DEVICE_TYPE_JC450` (57) in the `jimiOnlineCommand` check in `HuabaoProtocolEncoder`, so `TYPE_CUSTOM` selects subtype `0xF0`.
- Make `encodeTransparent` package-private; add `testEncodeTransparentJimiText` asserting the encoder output is byte-identical to the captured frame.

## Tests

`HuabaoProtocolEncoderTest` and `HuabaoProtocolDecoderTest` pass. Checkstyle failures are all pre-existing; the edited files report zero violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)