### PR TITLE
Decode T/JSATL12 ADAS/DMS alarm items into real events

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -172,6 +172,79 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
         return BitUtil.check(value, 15) ? -BitUtil.to(value, 15) : BitUtil.to(value, 15);
     }
 
+    private static final String[] ADAS_ALARM_TYPES = {
+            null, "forwardCollision", "laneDeparture", "followingDistance", "pedestrianCollision",
+            "frequentLaneChange", "roadSignOverrun", "obstacle",
+    };
+
+    private static final String[] DMS_ALARM_TYPES = {
+            null, "fatigue", "phoneUse", "smoking", "distraction", "driverAbnormal",
+            "handsOffWheel", "driverChange",
+    };
+
+    private void decodeActiveSafety(Position position, ByteBuf buf, boolean adas) {
+
+        // T/JSATL12 active-safety alarm body (0x64 ADAS, 0x65 DSM), 47 bytes.
+        // The additional-info loop resets to the item boundary afterwards, so it
+        // is safe to read only the useful fields.
+        long alarmId = buf.readUnsignedInt();
+        int flag = buf.readUnsignedByte(); // 0 = point event, 1 = start, 2 = end
+        int type = buf.readUnsignedByte();
+        int level = buf.readUnsignedByte();
+
+        String prefix = adas ? "adas" : "dms";
+        position.set(prefix + "Alarm", type);
+        position.set(prefix + "AlarmLevel", level);
+        if (flag == 1) {
+            position.set(prefix + "AlarmFlag", "start");
+        } else if (flag == 2) {
+            position.set(prefix + "AlarmFlag", "end");
+        }
+
+        String[] names = adas ? ADAS_ALARM_TYPES : DMS_ALARM_TYPES;
+        String name = type >= 0 && type < names.length ? names[type] : null;
+        if (name != null) {
+            position.set(prefix + "AlarmType", name);
+        }
+
+        if (adas) {
+            position.set("adasFrontSpeed", buf.readUnsignedByte());
+            position.set("adasFrontDistance", buf.readUnsignedByte());
+            int deviation = buf.readUnsignedByte();
+            if (deviation == 1) {
+                position.set("adasDeviation", "left");
+            } else if (deviation == 2) {
+                position.set("adasDeviation", "right");
+            }
+            buf.skipBytes(2); // road sign type and data
+        } else {
+            int fatigue = buf.readUnsignedByte();
+            if (type == 1 && fatigue > 0) {
+                position.set("fatigueDegree", fatigue);
+            }
+            buf.skipBytes(4); // reserved
+        }
+
+        buf.skipBytes(1 + 2 + 4 + 4 + 6 + 2); // speed, altitude, lat, lon, time, vehicle status
+
+        // Alarm identification number (16 bytes): terminal id (7), time (6),
+        // sequence (1), attachment count (1), reserved (1).
+        buf.skipBytes(7 + 6);
+        position.set("alarmSequence", buf.readUnsignedByte());
+        position.set("alarmAttachments", buf.readUnsignedByte());
+        position.set("alarmIndex", (int) (alarmId & 0xFFFFFFFFL));
+
+        if ("fatigue".equals(name)) {
+            position.set(Position.KEY_ALARM, Position.ALARM_FATIGUE_DRIVING);
+        } else if ("laneDeparture".equals(name) || "frequentLaneChange".equals(name)) {
+            position.set(Position.KEY_ALARM, Position.ALARM_LANE_CHANGE);
+        } else if ("forwardCollision".equals(name) || "pedestrianCollision".equals(name)) {
+            position.set(Position.KEY_ALARM, Position.ALARM_ACCIDENT);
+        } else {
+            position.set(Position.KEY_ALARM, Position.ALARM_GENERAL);
+        }
+    }
+
     private Date readDate(ByteBuf buf, TimeZone timeZone) {
         DateBuilder dateBuilder = new DateBuilder(timeZone)
                 .setYear(BcdUtil.readInteger(buf, 2))
@@ -784,14 +857,10 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
                     }
                     break;
                 case 0x64:
-                    buf.readUnsignedInt(); // alarm serial number
-                    buf.readUnsignedByte(); // alarm status
-                    position.set("adasAlarm", buf.readUnsignedByte());
+                    decodeActiveSafety(position, buf, true);
                     break;
                 case 0x65:
-                    buf.readUnsignedInt(); // alarm serial number
-                    buf.readUnsignedByte(); // alarm status
-                    position.set("dmsAlarm", buf.readUnsignedByte());
+                    decodeActiveSafety(position, buf, false);
                     break;
                 case 0x70:
                     buf.readUnsignedInt(); // alarm serial number

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
@@ -50,6 +50,27 @@ public class HuabaoProtocolDecoderTest extends ProtocolTest {
                 "mediaEvent", 3);
 
         verifyAttribute(decoder, binary(
+                "7e020000744f0ebc3a18a4cfc6000408000004000f01b23db502e881f40009013600812609061453"
+                        + "56010400009fdc30011f31011214040000000115040000000217020000eb095554432d30333a30"
+                        + "30652f0000000000010100000000001f0009fe4dc24bfd177e0c260906145355ffff3036303435"
+                        + "323426090614535500050003" + "7e"),
+                Position.KEY_ALARM, Position.ALARM_FATIGUE_DRIVING);
+
+        verifyAttribute(decoder, binary(
+                "7e020000744f0ebc3a18a4cfc6000408000004000f01b23db502e881f40009013600812609061453"
+                        + "56010400009fdc30011f31011214040000000115040000000217020000eb095554432d30333a30"
+                        + "30652f0000000000010100000000001f0009fe4dc24bfd177e0c260906145355ffff3036303435"
+                        + "323426090614535500050003" + "7e"),
+                "alarmAttachments", 5);
+
+        verifyAttribute(decoder, binary(
+                "7e020000744f0ebc3a18a4cfc6000408000004000f01b23db502e881f40009013600812609061453"
+                        + "56010400009fdc30011f31011214040000000115040000000217020000eb095554432d30333a30"
+                        + "30652f0000000000010100000000001f0009fe4dc24bfd177e0c260906145355ffff3036303435"
+                        + "323426090614535500050003" + "7e"),
+                "dmsAlarmType", "fatigue");
+
+        verifyAttribute(decoder, binary(
                 "7e01040015013345678906000100010200000001040000003c0000001804000027109f7e"),
                 "parameters", "{\"0x1\":\"0000003c\",\"0x18\":\"00002710\"}");
 


### PR DESCRIPTION
## Problem

The Jimi JC450 fleet reports active-safety events (fatigue, distraction, forward collision, lane departure…) as a **T/JSATL12 `0x64` (ADAS) / `0x65` (DMS) additional item** inside a `0x0200` location report. `HuabaoProtocolDecoder` read only 6 of the 47 bytes and set an opaque `adasAlarm` / `dmsAlarm` number — never `Position.KEY_ALARM` — so the events never became Traccar events or notifications.

## Full decode

Confirmed byte-for-byte against a real JC450 fatigue frame (device `400222`, `2026-09-06 14:53:56`):

| Field | Offset | Value in sample |
|---|---|---|
| alarm id | 0 (4) | 0 |
| flag state | 4 (1) | 0 = point event (1 = start, 2 = end) |
| event type | 5 (1) | `0x01` = fatigue |
| level | 6 (1) | 1 |
| DMS: fatigue degree + reserved / ADAS: front speed, distance, deviation, sign | 7 (5) | — |
| speed, altitude, lat, lon (signed ×1e6), time BCD, vehicle status | 12 (19) | 31 km/h, 9 m, -28.458421, -48.792052 (matches the report) |
| alarm identification number: terminal id (7), time (6), sequence (1), **attachment count (1)**, reserved (1) | 31 (16) | seq 0, **attachments 5** |

## Change

- New `decodeActiveSafety()` parses the whole item.
- `Position.KEY_ALARM` mapping: fatigue → `fatigueDriving`, lane departure / frequent lane change → `laneChange`, forward / pedestrian collision → `accident`, everything else → `general`.
- Exposes `adasAlarmType` / `dmsAlarmType` (specific name), `adasAlarmLevel` / `dmsAlarmLevel`, `…AlarmFlag` (start/end), `fatigueDegree`, `alarmSequence`, and **`alarmAttachments`** — the count the future `0x9208` → `0x1210/1211/1212` upload flow will key on.
- Keeps the legacy `adasAlarm` / `dmsAlarm` numeric attribute.

## Tests

`HuabaoProtocolDecoderTest` extended with the real frame: `KEY_ALARM` = `fatigueDriving`, `dmsAlarmType` = `fatigue`, `alarmAttachments` = 5. Full suite passes. Checkstyle `MethodLength` failures on `decode` / `decodeLocation` are pre-existing.

## Not included

The alarm-attachment upload (`0x9208` reply + `0x1210/1211/1212` + file channel) to actually retrieve the event clips/photos — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)