### PR TITLE
Request ADAS/DMS event media over HTTP (VIDEOUPLOAD)

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
+import org.traccar.Context;
 import org.traccar.DeviceSession;
 import org.traccar.NetworkMessage;
 import org.traccar.Protocol;
@@ -132,6 +133,29 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
         }
     }
 
+    // When an ADAS/DMS alarm carries attachments, ask the camera to POST the
+    // event's media (clip + snapshots) to an external HTTP endpoint, keyed by the
+    // alarm identification number. Off unless huabao.attachmentUrl is configured.
+    private void requestEventAttachments(
+            Channel channel, SocketAddress remoteAddress, ByteBuf id, Position position) {
+        if (channel == null || position == null || position.getInteger("alarmAttachments") <= 0) {
+            return;
+        }
+        String identifier = position.getString("alarmIdentifier");
+        String host = Context.getConfig().getString(getProtocolName() + ".attachmentUrl");
+        if (identifier == null || host == null) {
+            return;
+        }
+        int port = Context.getConfig().getInteger(getProtocolName() + ".attachmentPort", 80);
+        int camera = Context.getConfig().getInteger(getProtocolName() + ".attachmentChannel", 1);
+        String command = "VIDEOUPLOAD," + host + "," + port + "," + identifier + "," + camera + ",2#";
+        channel.writeAndFlush(new NetworkMessage(
+                HuabaoProtocolEncoder.encodeTransparent(id, command, 0xF0), remoteAddress));
+        LOGGER.error(
+                "Huabao event attachment request deviceId={} identifier={} attachments={}",
+                position.getDeviceId(), identifier, position.getInteger("alarmAttachments"));
+    }
+
     private String decodeAlarm(long value) {
         if (BitUtil.check(value, 0)) {
             return Position.ALARM_SOS;
@@ -228,11 +252,16 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
         buf.skipBytes(1 + 2 + 4 + 4 + 6 + 2); // speed, altitude, lat, lon, time, vehicle status
 
         // Alarm identification number (16 bytes): terminal id (7), time (6),
-        // sequence (1), attachment count (1), reserved (1).
-        buf.skipBytes(7 + 6);
-        position.set("alarmSequence", buf.readUnsignedByte());
-        position.set("alarmAttachments", buf.readUnsignedByte());
+        // sequence (1), attachment count (1), reserved (1). The whole block, hex
+        // encoded, is the id the VIDEOUPLOAD / 0x9208 attachment request uses.
         position.set("alarmIndex", (int) (alarmId & 0xFFFFFFFFL));
+        if (buf.readableBytes() >= 16) {
+            byte[] identifier = new byte[16];
+            buf.readBytes(identifier);
+            position.set("alarmIdentifier", ByteBufUtil.hexDump(identifier));
+            position.set("alarmSequence", identifier[13] & 0xFF);
+            position.set("alarmAttachments", identifier[14] & 0xFF);
+        }
 
         if ("fatigue".equals(name)) {
             position.set(Position.KEY_ALARM, Position.ALARM_FATIGUE_DRIVING);
@@ -504,7 +533,10 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
 
             sendGeneralResponse(channel, remoteAddress, id, type, index);
 
-            return decodeLocation(deviceSession, buf, type);
+            Position location = decodeLocation(deviceSession, buf, type);
+            requestEventAttachments(
+                    channel, remoteAddress, Unpooled.wrappedBuffer(ByteBufUtil.getBytes(buf, 5, 6)), location);
+            return location;
 
         } else if (type == MSG_MULTIMEDIA_EVENT) {
 

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolDecoderTest.java
@@ -71,6 +71,13 @@ public class HuabaoProtocolDecoderTest extends ProtocolTest {
                 "dmsAlarmType", "fatigue");
 
         verifyAttribute(decoder, binary(
+                "7e020000744f0ebc3a18a4cfc6000408000004000f01b23db502e881f40009013600812609061453"
+                        + "56010400009fdc30011f31011214040000000115040000000217020000eb095554432d30333a30"
+                        + "30652f0000000000010100000000001f0009fe4dc24bfd177e0c260906145355ffff3036303435"
+                        + "323426090614535500050003" + "7e"),
+                "alarmIdentifier", "30363034353234260906145355000500");
+
+        verifyAttribute(decoder, binary(
                 "7e01040015013345678906000100010200000001040000003c0000001804000027109f7e"),
                 "parameters", "{\"0x1\":\"0000003c\",\"0x18\":\"00002710\"}");
 


### PR DESCRIPTION
## What

Builds on #529. A `0x64`/`0x65` alarm names an attachment set — the event clip + snapshots the JC450 records to SD and never uploads on its own (our sample frame: **5 attachments**). This makes Traccar ask for them.

- `decodeActiveSafety` now emits the full **16-byte alarm identification number** as `alarmIdentifier` (32 hex) — the id both `VIDEOUPLOAD` and `0x9208` use to key the set. `alarmSequence` / `alarmAttachments` are read out of that same block.
- After a `0x0200` location report, if the position has `alarmAttachments > 0` **and** `huabao.attachmentUrl` is set, Traccar sends the camera:

  ```
  VIDEOUPLOAD,<host>,<port>,<alarmIdentifier>,<channel>,2#
  ```

  as a `0xF0` transparent command — the JC182/JC400-family "upload this event's media to an external HTTP server" command. The camera then HTTP-POSTs the clip + JPEGs to that endpoint.

## Config

| key | default | |
|---|---|---|
| `huabao.attachmentUrl` | — | HTTP host; **feature is off unless set** |
| `huabao.attachmentPort` | 80 | |
| `huabao.attachmentChannel` | 1 | camera channel (JC450 records only ch1) |

## Not in scope

The HTTP endpoint that receives the POST (separate repo). And this is the `VIDEOUPLOAD` path — the binary `0x9208` → `0x1210/1211/1212` flow is not implemented.

## Verified

Real JC450 fatigue frame decodes to `alarmIdentifier` `30363034353234260906145355000500` (terminal `0604524`, seq 0, 5 attachments). `UPLOAD#` / `URLTYPE#` queried live on a JC450: `UPLOAD Not Set`, `URLTYPE,http` — the upload slot exists and is settable. `HuabaoProtocolDecoderTest` extended; suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)