### PR TITLE
Enable Huabao event-attachment upload

### DIFF
--- a/traccar.xml
+++ b/traccar.xml
@@ -111,4 +111,8 @@
 
   <entry key='log.protocol'></entry>
 
+  <!-- Where JC450 dashcams POST ADAS/DMS event media after a VIDEOUPLOAD. -->
+  <entry key='huabao.attachmentUrl'>media-ip.n-gps.com</entry>
+  <entry key='huabao.attachmentPort'>10005</entry>
+
 </properties>


### PR DESCRIPTION
Sets `huabao.attachmentUrl` = `media-ip.n-gps.com` and `huabao.attachmentPort` = `10005`, which turns on the `VIDEOUPLOAD` trigger from the decoder (#530). On a JC450 ADAS/DMS alarm with attachments, Traccar now asks the camera to POST the event clip + snapshots to the upload sink (jcardus/media-server#2).

Config only. Deploy restarts Traccar so the new keys are read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)