### PR TITLE
Huabao ADAS/DMS event media + metadata

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -162,7 +162,13 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
         postEventMetadata(host, port, identifier, position);
     }
 
-    private static final HttpClient METADATA_CLIENT = HttpClient.newHttpClient();
+    // HTTP/1.1 explicitly: the default client tries an h2c upgrade first, and on a
+    // plain HTTP/1.1 sink that can leave the POST body without a Content-Length,
+    // which crashes the sink's keep-alive parser.
+    private static final HttpClient METADATA_CLIENT = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
 
     // The alarm identification number the sink files under carries the event time
     // but not the type, so hand the sink {type, alarm, level, ...}. Fire and


### PR DESCRIPTION
Promotes the Huabao active-safety event pipeline to production.

- Decode text replies on the 0x0900 / 0xF0 subtype
- Send JC450 text commands as 0xF0 transparent (like JC181/JC371)
- Decode T/JSATL12 ADAS/DMS alarm items into real events (KEY_ALARM + alarmIdentifier)
- Request event media over HTTP (VIDEOUPLOAD) to the upload sink
- POST event metadata (type/alarm/level) to the sink so events show their real type
- Force HTTP/1.1 for that metadata POST (h2c upgrade was crashing the sink's parser)
- Request DMS event media from the cabin camera, not the road camera
  (JC450 cabin lens = channel 3, other models = 2; huabao.attachmentChannelDms overrides)
- Decode SD-card recording times (0x1205) and the video-list / playback commands in
  the camera's local zone instead of UTC (huabao.videoTimezone, falls back to
  decoder.timezone, then UTC)

traccar.xml adds:
- huabao.attachmentUrl / huabao.attachmentPort (media sink)
- huabao.videoTimezone = America/Sao_Paulo

🤖 Generated with [Claude Code](https://claude.com/claude-code)