### PR TITLE
Decode SD-card recording times in the camera's local zone

### DIFF
--- a/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolDecoder.java
@@ -463,6 +463,10 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
 
             buf.readUnsignedShort(); // response serial number
             long total = buf.readUnsignedInt();
+            // The camera stamps SD-card recordings in its own local time, not UTC,
+            // so decode them with the device timezone (decoder.timezone), same as
+            // location reports.
+            TimeZone videoTimeZone = deviceSession.get(DeviceSession.KEY_TIMEZONE);
             StringBuilder resources = new StringBuilder("[");
             int count = 0;
             while (buf.readableBytes() >= 28 && count < total) {
@@ -471,9 +475,9 @@ public class HuabaoProtocolDecoder extends BaseProtocolDecoder {
                 }
                 resources.append('{');
                 resources.append("\"channel\":").append(buf.readUnsignedByte()).append(',');
-                resources.append("\"startTime\":").append(readDate(buf, TimeZone.getTimeZone("UTC")).getTime())
+                resources.append("\"startTime\":").append(readDate(buf, videoTimeZone).getTime())
                         .append(',');
-                resources.append("\"endTime\":").append(readDate(buf, TimeZone.getTimeZone("UTC")).getTime())
+                resources.append("\"endTime\":").append(readDate(buf, videoTimeZone).getTime())
                         .append(',');
                 resources.append("\"alarmFlag\":").append(buf.readLong()).append(',');
                 resources.append("\"resourceType\":").append(buf.readUnsignedByte()).append(',');

--- a/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
+++ b/src/main/java/org/traccar/protocol/HuabaoProtocolEncoder.java
@@ -62,17 +62,28 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
         return Unpooled.wrappedBuffer(DataConverter.parseHex(uniqueId));
     }
 
-    private static void writeDate(ByteBuf data, String value) {
+    // Cameras index SD-card recordings in their own local time, so the video
+    // list / playback commands must send timestamps in that zone, matching
+    // HuabaoProtocolDecoder's decode of the 0x1205 reply. Use the device
+    // timezone (decoder.timezone), same as location reports, else UTC.
+    private TimeZone videoTimeZone(long deviceId) {
+        String name = Context.getIdentityManager().lookupAttributeString(
+                deviceId, "decoder.timezone", null, false, true);
+        return TimeZone.getTimeZone(name != null ? name : "UTC");
+    }
+
+    private static void writeDate(ByteBuf data, String value, TimeZone timeZone) {
         Date date = DateUtil.parseDate(value);
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyMMddHHmmss");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        dateFormat.setTimeZone(timeZone);
         data.writeBytes(DataConverter.parseHex(dateFormat.format(date)));
     }
 
-    static void encodeVideoListData(ByteBuf data, int channel, String startTime, String endTime, long alarmFlag) {
+    static void encodeVideoListData(
+            ByteBuf data, int channel, String startTime, String endTime, long alarmFlag, TimeZone timeZone) {
         data.writeByte(channel); // logical channel, 0 = all channels
-        writeDate(data, startTime);
-        writeDate(data, endTime);
+        writeDate(data, startTime, timeZone);
+        writeDate(data, endTime, timeZone);
         data.writeLong(alarmFlag); // 0 = all alarm types, otherwise a JT/T 1078 alarm bitmask
         data.writeByte(2); // audio and video
         data.writeByte(0); // all stream types
@@ -178,7 +189,8 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
                             command.getInteger(Command.KEY_INDEX),
                             command.getString(Command.KEY_START_TIME),
                             command.getString(Command.KEY_END_TIME),
-                            command.getLong(Command.KEY_ALARM_FLAG));
+                            command.getLong(Command.KEY_ALARM_FLAG),
+                            videoTimeZone(command.getDeviceId()));
                     return HuabaoProtocolDecoder.formatMessage(
                             HuabaoProtocolDecoder.MSG_VIDEO_LIST, id, false, data);
                 case Command.TYPE_VIDEO_PLAYBACK:
@@ -194,8 +206,9 @@ public class HuabaoProtocolEncoder extends BaseProtocolEncoder {
                     data.writeByte(command.getInteger(Command.KEY_STORAGE_TYPE));
                     data.writeByte(0); // normal playback
                     data.writeByte(0); // normal speed
-                    writeDate(data, command.getString(Command.KEY_START_TIME));
-                    writeDate(data, command.getString(Command.KEY_END_TIME));
+                    TimeZone playbackTimeZone = videoTimeZone(command.getDeviceId());
+                    writeDate(data, command.getString(Command.KEY_START_TIME), playbackTimeZone);
+                    writeDate(data, command.getString(Command.KEY_END_TIME), playbackTimeZone);
                     return HuabaoProtocolDecoder.formatMessage(
                             HuabaoProtocolDecoder.MSG_VIDEO_PLAYBACK, id, false, data);
                 case Command.TYPE_GET_DEVICE_STATUS:

--- a/src/test/java/org/traccar/protocol/HuabaoProtocolEncoderTest.java
+++ b/src/test/java/org/traccar/protocol/HuabaoProtocolEncoderTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 import org.traccar.ProtocolTest;
 import org.traccar.model.Command;
 
+import java.util.TimeZone;
+
 public class HuabaoProtocolEncoderTest extends ProtocolTest {
 
     @Test
@@ -38,7 +40,8 @@ public class HuabaoProtocolEncoderTest extends ProtocolTest {
         ByteBuf data = Unpooled.buffer();
         try {
             HuabaoProtocolEncoder.encodeVideoListData(
-                    data, 0, "2026-08-31T09:29:16.000Z", "2026-08-31T09:29:36.000Z", 0);
+                    data, 0, "2026-08-31T09:29:16.000Z", "2026-08-31T09:29:36.000Z", 0,
+                    TimeZone.getTimeZone("UTC"));
             assertEquals("002608310929162608310929360000000000000000020000", ByteBufUtil.hexDump(data));
         } finally {
             data.release();
@@ -50,7 +53,8 @@ public class HuabaoProtocolEncoderTest extends ProtocolTest {
         ByteBuf data = Unpooled.buffer();
         try {
             HuabaoProtocolEncoder.encodeVideoListData(
-                    data, 3, "2026-08-31T09:29:16.000Z", "2026-08-31T09:29:36.000Z", 0x100000000L);
+                    data, 3, "2026-08-31T09:29:16.000Z", "2026-08-31T09:29:36.000Z", 0x100000000L,
+                    TimeZone.getTimeZone("UTC"));
             assertEquals("032608310929162608310929360000000100000000020000", ByteBufUtil.hexDump(data));
         } finally {
             data.release();


### PR DESCRIPTION
Cameras index SD recordings in local time, but the 0x1205 decode and the video-list / playback encode both used UTC, so the recordings table showed times ~3h off and range filtering missed edge recordings. Decode and encode those timestamps with the device timezone (decoder.timezone), same as location reports, so the epochs are real instants.